### PR TITLE
Make initial example work

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ index.html
 <html>
 <head>
     <title>Binding example</title>
-    <script src="milo.bundle.js"></script>
-    <script src="index.js"></script>
 </head>
 <body>
     <input type="text" ml-bind="[Data]:myField">
@@ -55,6 +53,8 @@ index.html
       <h2>I am connected:</h2>
       <span ml-bind="[Data]:myTestValue2"></span>
     </div>
+    <script src="milo.bundle.js"></script>
+    <script src="index.js"></script>
 </body>
 </html>
 ```
@@ -77,13 +77,13 @@ milo(function () {
     // attach subscriber to click event via events facet
     // of myTestButton component
     scope.myTestButton.events.on('click', function(msg, event) {
-    	scope.myTestValue.el.innerHTML = ctrl.myField.data.value();
+    	scope.myTestValue.el.innerHTML = scope.myField.data.value();
     });
 
     // connect two components directly via their data facets
     // using milo.minder
     milo.minder(scope.myField.data, '->', scope.myTestValue2.data);
-}
+}());
 ```
 
 


### PR DESCRIPTION
The initial example has some issues:
- The JS itself is invalid, I believe it's meant to be an IIFE, so I have fixed that.
- It references an undefined variable (`ctrl`) which I believe should be `scope`.
- I Moved the `<script>` tags to bottom of the page to defer execution until the page has actually loaded.
