### PR TITLE
bumped to version 1 the grunt-contrib-uglify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt": "~0.4.1",
     "grunt-browserify": "~1.2.11",
     "grunt-contrib-copy": "^0.8.2",
-    "grunt-contrib-uglify": "~0.2.7",
+    "grunt-contrib-uglify": "~1",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-exorcise": "^1.0.0",
     "grunt-istanbul": "^0.6.1",


### PR DESCRIPTION
In order to avoid deprecation warnings about source map, I've bumped this dependency which seems to work just fine at version 1.