### PR TITLE
[clean-up] externally resolvable abortable promises

### DIFF
--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -3,7 +3,7 @@
 // milo.utils.request
 // -----------
 
-// Convenience functions wrapping XMLHTTPRequest functionality.
+// Convenience functions wrapping XMLHttpRequest functionality.
 
 // ```
 // var request = milo.utils.request
@@ -22,6 +22,7 @@
 
 
 var miloCore = require('milo-core')
+    , Dodgy = require('dodgy').Promise
     , _ = miloCore.proto
     , uniqueId = require('./unique_id')
     , config = require('../config')
@@ -44,21 +45,6 @@ module.exports = request;
 
 
 var _pendingRequests = [];
-
-var promiseThen = createPromiseOverride('then');
-var promiseCatch = createPromiseOverride('catch');
-
-/**
- * Creates a function which is used to override standard promise behaviour and allow promise instances
- * created to maintain a reference to the request object no matter if .then() or .catch() is called.
- */
-function createPromiseOverride(functionName) {
-    return function() {
-        var promise = Promise.prototype[functionName].apply(this, arguments);
-        keepRequestObject(promise, this._request);
-        return promise;
-    };
-}
 
 function request(url, opts, callback) {
     opts.url = url;
@@ -98,7 +84,7 @@ function request(url, opts, callback) {
         {timeout: req.timeout}
     );
 
-    return xPromise.promise;
+    return abortable(xPromise);
 
     function onReady(e) {
         _onReady(req, callback, xPromise, e.type);
@@ -106,29 +92,23 @@ function request(url, opts, callback) {
 }
 
 
-function _createXPromise(request) {
-    var resolvePromise, rejectPromise;
-    var promise = new Promise(function(resolve, reject) {
-        resolvePromise = resolve;
-        rejectPromise = reject;
-    });
-
-    keepRequestObject(promise, request);
-    promise.catch(_.noop); // Sometimes errors are handled within callbacks, so uncaught promise error message should be suppressed.
-
-    return {
-        promise: promise,
-        resolve: resolvePromise,
-        reject: rejectPromise
-    };
+function _createXPromise(hosted) {
+    return new Dodgy(
+        (k, n, onAbort) => onAbort(() => {
+            // only if the hosted object has an abort
+            // example: if it's a script, don't call it
+            if (hosted.abort) hosted.abort();
+        }),
+        true
+    );
 }
 
-// Ensures that the promise (and any promises created when calling .then/.catch) has a reference to the original request object
-function keepRequestObject(promise, request) {
-    promise._request = request;
-    promise.then = promiseThen;
-    promise.catch = promiseCatch;
-
+function abortable(dodgy) {
+    // in order to keep the resolvable Promise
+    // in this module scope, pass a regular
+    // promise able to abort the request
+    var promise = Promise.resolve(dodgy);
+    promise.abort = dodgy.abort;
     return promise;
 }
 
@@ -275,7 +255,7 @@ function request$jsonp(url, callback) {
 
     head.appendChild(script);
 
-    return xPromise.promise;
+    return abortable(xPromise);
 
 
     function _onResult(err, result) {
@@ -347,7 +327,7 @@ function request$file(opts, fileData, callback, progress) {
 
     if (opts.trackCompletion !== false) _pendingRequests.push(req);
 
-    return xPromise.promise;
+    return abortable(xPromise);
 
     function onReady(e) {
         if (progress) req.upload.onprogress = undefined;

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -94,11 +94,13 @@ function request(url, opts, callback) {
 
 function _createXPromise(hosted) {
     return new Dodgy(
-        (k, n, onAbort) => onAbort(() => {
-            // only if the hosted object has an abort
-            // example: if it's a script, don't call it
-            if (hosted.abort) hosted.abort();
-        }),
+        function (k, n, onAbort) {
+            onAbort(function () {
+                // only if the hosted object has an abort
+                // example: if it's a script, don't call it
+                if (hosted.abort) hosted.abort();
+            });
+        },
         true
     );
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "base32": "milojs/base32-js.git",
     "milo-core": "^1.0.3",
-    "querystringparser": "^0.1.1"
+    "querystringparser": "^0.1.1",
+    "dodgy": "1.3.0"
   },
   "devDependencies": {
     "async": "~0.2.9",


### PR DESCRIPTION
As explained offline I'd like to propose a cleaner patterns on milo core.

```js
// current anti-pattern
var resolve, reject;
var passedAround = {
    promise: new Promise(function (res, rej) {
        resolve = res;
        reject = rej;
    })
};
var xhr = new XMLHttpRequest();
xhr.open('GET', url, true);
xhr.onloadend = function () {
    passedAround.resolve(this);
};
xhr.send(null);
passedAround.resolve = resolve;
passedAround.reject = reject;
return passedAround;

// better Promise way
return new Promise(function (resolve, reject) {
    var xhr = new XMLHttpRequest();
    xhr.open('GET', url, true);
    xhr.onloadend = function () {
        resolve(this);
    };
    xhr.send(null);
});
```

The introduction of Dodgy, which name is not casual, helps starting cleaning up with this approach, specially exposing [cancelabilty](https://github.com/domenic/cancelable-promise) in a better, more future friendly way, instead of having a dirty property attached with an underscore per each promise returned after a `.then(call)`

The final goal is to clean up further as we can and fully get rid of Dodgy as dependency, avoiding the need to extract reject and resolve with the request module, and using official way to cancel the returned promise.