### PR TITLE
Smarter getScopeParentWithClass via name

### DIFF
--- a/lib/components/c_class.js
+++ b/lib/components/c_class.js
@@ -767,10 +767,12 @@ function _getScopeParent(conditionFunc) {
  * Component instance method
  * Returns scope parent with a given class, with same class if not specified
  *
- * @param {Function} [ComponentClass] component class that the parent should have, same class by default
+ * @param {Function|String} [ComponentClass] component class or name that the parent should have, same class by default
  * @return {Component}
  */
 function Component$getScopeParentWithClass(ComponentClass) {
+    if (typeof ComponentClass === 'string')
+        ComponentClass = milo.registry.components.get(ComponentClass);
     ComponentClass = ComponentClass || this.constructor;
     return _getScopeParent.call(this, function(comp) {
         return comp instanceof ComponentClass;


### PR DESCRIPTION
This PR aim is to simplify the discovery of a parent component without needing to include, or directly reference, its class.