### PR TITLE
Using a cleaner approach to abort requests.

### DIFF
--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -56,98 +56,83 @@ var promiseCatch = createPromiseOverride('catch');
  */
 function createPromiseOverride(functionName) {
     return function() {
-        var promise = Promise.prototype[functionName].apply(this, arguments);
-        keepRequestObject(promise, this._request);
-        return promise;
+        return addAbortAbility(
+            Promise.prototype[functionName].apply(this, arguments),
+            this.abort
+        );
     };
 }
 
 function request(url, opts, callback) {
+    var abort;
+
     opts.url = url;
     opts.contentType = opts.contentType || 'application/json;charset=UTF-8';
 
     if (_messenger) request.postMessageSync('request', { options: opts });
 
-    var req = new XMLHttpRequest();
-    req.open(opts.method, opts.url, (opts.sync ? false : true));
-    req.setRequestHeader('Content-Type', opts.contentType);
-    setRequestHeaders(req, opts.headers);
+    return addAbortAbility(
+        new Promise(function (resolve, reject) {
+            var req = new XMLHttpRequest();
+            req.open(opts.method, opts.url, (opts.sync ? false : true));
+            req.setRequestHeader('Content-Type', opts.contentType);
+            setRequestHeaders(req, opts.headers);
 
-    if (!opts.sync) req.timeout = opts.timeout || config.request.defaults.timeout;
-    req.onloadend = req.ontimeout = req.onabort = onReady;
+            if (!opts.sync) req.timeout = opts.timeout || config.request.defaults.timeout;
 
-    var xPromise = _createXPromise(req);
+            req.onloadend = req.ontimeout = req.onabort = function (e) {
+                abort = null;
+                _onReady(e.type, req, callback, resolve, reject);
+            };
 
-    req[config.request.optionsKey] = opts;
+            req[config.request.optionsKey] = opts;
 
-    if (opts.trackCompletion !== false) _pendingRequests.push(req);
+            if (opts.trackCompletion !== false) _pendingRequests.push(req);
 
-    /**
-     * There are cases where the cached response
-     * might trigger faster than a chained Promise
-     * through its `.then()` callback.
-     * In these cases it makes sense to return
-     * the Promise first and trigger
-     * the request after, whenever the CPU
-     * is not busy but also never later than
-     * specified request timeout.
-     */
-    var data = opts.data;
-    var ric = requestIdleCallback(
-        function (deadline) {
-            ric = null;
-            try {
-                req.send(JSON.stringify(data));
-            } catch (e) {
-                console.error('Request Error: ', url, e, opts);
-            }
-        },
-        {timeout: req.timeout}
+            /**
+             * There are cases where the cached response
+             * might trigger faster than a chained Promise
+             * through its `.then()` callback.
+             * In these cases it makes sense to return
+             * the Promise first and trigger
+             * the request after, whenever the CPU
+             * is not busy but also never later than
+             * specified request timeout.
+             */
+            var data = opts.data;
+            var ric = requestIdleCallback(
+                function (deadline) {
+                    ric = null;
+                    try {
+                        req.send(JSON.stringify(data));
+                    } catch (e) {
+                        console.error('Request Error: ', url, e, opts);
+                    }
+                },
+                {timeout: req.timeout}
+            );
+
+            abort = function () {
+                if (abort && !ric) {
+                    req.abort();
+                } else if (ric) {
+                    cancelIdleCallback(ric);
+                    ric = null;
+                }
+                abort = null;
+            };
+
+        }),
+        abort
     );
 
-    var abort = req.abort;
-    req.abort = function () {
-        if (abort && !ric) {
-            abort.call(req);
-        } else if (ric) {
-            cancelIdleCallback(ric);
-            ric = null;
-        }
-        abort = null;
-    };
-
-    return xPromise.promise;
-
-    function onReady(e) {
-        abort = null;
-        _onReady(req, callback, xPromise, e.type);
-    }
-}
-
-
-function _createXPromise(request) {
-    var resolvePromise, rejectPromise;
-    var promise = new Promise(function(resolve, reject) {
-        resolvePromise = resolve;
-        rejectPromise = reject;
-    });
-
-    keepRequestObject(promise, request);
-    promise.catch(_.noop); // Sometimes errors are handled within callbacks, so uncaught promise error message should be suppressed.
-
-    return {
-        promise: promise,
-        resolve: resolvePromise,
-        reject: rejectPromise
-    };
 }
 
 // Ensures that the promise (and any promises created when calling .then/.catch) has a reference to the original request object
-function keepRequestObject(promise, request) {
-    promise._request = request;
+function addAbortAbility(promise, abort) {
+    promise.abort = abort;
     promise.then = promiseThen;
     promise.catch = promiseCatch;
-
     return promise;
 }
 
@@ -159,7 +144,7 @@ function setRequestHeaders(req, headers) {
         });
 }
 
-function _onReady(req, callback, xPromise, eventType) {
+function _onReady(eventType, req, callback, resolve, reject) {
     if (req.readyState != 4) return;
     if (req[config.request.completedKey]) return;
 
@@ -172,7 +157,7 @@ function _onReady(req, callback, xPromise, eventType) {
                 postMessage('success');
                 callback && callback(null, req.responseText, req);
             } catch(e) { error = e; }
-            xPromise.resolve(req.responseText);
+            resolve(req.responseText);
         }
         else {
             var errorReason = req.status || eventType;
@@ -181,7 +166,7 @@ function _onReady(req, callback, xPromise, eventType) {
                 postMessage('error' + errorReason);
                 callback && callback(errorReason, req.responseText, req);
             } catch(e) { error = e; }
-            xPromise.reject({ reason: errorReason, response: req.responseText });
+            reject({ reason: errorReason, response: req.responseText });
         }
     } catch(e) {
         error = error || e;
@@ -269,109 +254,131 @@ function request$json(url, callback) {
 
 var jsonpOptions = { method: 'GET', jsonp: true };
 function request$jsonp(url, callback) {
-    var script = document.createElement('script'),
-        xPromise = _createXPromise(script),
-        head = window.document.head,
-        uniqueCallback = config.request.jsonpCallbackPrefix + uniqueId();
+    var abort;
+    return addAbortAbility(
+        new Promise(function (resolve, reject) {
+            var script = document.createElement('script'),
+                head = window.document.head,
+                uniqueCallback = config.request.jsonpCallbackPrefix + uniqueId();
 
-    var opts = _.extend({ url: url }, jsonpOptions);
-    if (_messenger) request.postMessageSync('request', { options: opts });
+            var opts = _.extend({ url: url }, jsonpOptions);
+            if (_messenger) request.postMessageSync('request', { options: opts });
 
-    if (! _.isEqual(_.omitKeys(opts, 'url'), jsonpOptions))
-        logger.warn('Ignored not allowed request options change in JSONP request - only URL can be changed');
+            if (! _.isEqual(_.omitKeys(opts, 'url'), jsonpOptions))
+                logger.warn('Ignored not allowed request options change in JSONP request - only URL can be changed');
 
-    var timeout = setTimeout(function() {
-        var err = new Error('No JSONP response or no callback in response');
-        _onResult(err);
-    }, config.request.jsonpTimeout);
+            var timeout = setTimeout(function() {
+                var err = new Error('No JSONP response or no callback in response');
+                _onResult(err);
+            }, config.request.jsonpTimeout);
 
-    window[uniqueCallback] = _.partial(_onResult, null);
+            window[uniqueCallback] = _.partial(_onResult, null);
 
-    _pendingRequests.push(window[uniqueCallback]);
+            _pendingRequests.push(window[uniqueCallback]);
 
-    script.type = 'text/javascript';
-    script.src = opts.url + (opts.url.indexOf('?') == -1 ? '?' : '&') + 'callback=' + uniqueCallback;
+            script.type = 'text/javascript';
+            script.src = opts.url + (opts.url.indexOf('?') == -1 ? '?' : '&') + 'callback=' + uniqueCallback;
 
-    head.appendChild(script);
+            head.appendChild(script);
 
-    return xPromise.promise;
+            function _onResult(err, result) {
+                abort = null;
+                _.spliceItem(_pendingRequests, window[uniqueCallback]);
+                var error;
+                try {
+                    postMessage(err ? 'error' : 'success', err, result);
+                    if (err) {
+                        logger.error('No JSONP response or timeout');
+                        postMessage('errorjsonptimeout', err);
+                    }
+                    callback && callback(err, result);
+                }
+                catch(e) { error = e; }
+                if (err) reject(err);
+                else resolve(result);
 
+                cleanUp();
+                if (!_pendingRequests.length)
+                    postMessage('requestscompleted');
 
-    function _onResult(err, result) {
-        _.spliceItem(_pendingRequests, window[uniqueCallback]);
-        var error;
-        try {
-            postMessage(err ? 'error' : 'success', err, result);
-            if (err) {
-                logger.error('No JSONP response or timeout');
-                postMessage('errorjsonptimeout', err);
+                if (error) throw error;
             }
-            callback && callback(err, result);
-        }
-        catch(e) { error = e; }
-        if (err) xPromise.reject(err);
-        else xPromise.resolve(result);
-
-        cleanUp();
-        if (!_pendingRequests.length)
-            postMessage('requestscompleted');
-
-        if (error) throw error;
-    }
 
 
-    function cleanUp() {
-        clearTimeout(timeout);
-        head.removeChild(script);
-        delete window[uniqueCallback];
-    }
+            function cleanUp() {
+                clearTimeout(timeout);
+                head.removeChild(script);
+                delete window[uniqueCallback];
+            }
 
 
-    function postMessage(msg, status, result) {
-        if (_messenger) request.postMessage(msg,
-            { status: status, response: result });
-    }
+            function postMessage(msg, status, result) {
+                if (_messenger) request.postMessage(msg,
+                    { status: status, response: result });
+            }
+
+            // there's no official way to drop a JSONP request
+            // if not ignoring it and cleaning it up once it happens.
+            abort = function () {
+                if (abort) {
+                    abort = null;
+                    window[uniqueCallback] = cleanUp;
+                }
+            };
+
+        }),
+        abort
+    );
 }
 
 
 function request$file(opts, fileData, callback, progress) {
-    if (typeof opts == 'string')
-        opts = { method: 'POST', url: opts };
+    var abort;
+    return addAbortAbility(
+        new Promise(function (resolve, reject) {
+            if (typeof opts == 'string')
+                opts = { method: 'POST', url: opts };
 
-    opts.method = opts.method || 'POST';
-    opts.file = true;
+            opts.method = opts.method || 'POST';
+            opts.file = true;
 
-    if (_messenger) request.postMessageSync('request', { options: opts });
+            if (_messenger) request.postMessageSync('request', { options: opts });
 
-    var req = new XMLHttpRequest();
-    if (progress) req.upload.onprogress = progress;
+            var req = new XMLHttpRequest();
+            if (progress) req.upload.onprogress = progress;
 
-    req.open(opts.method, opts.url, true);
-    setRequestHeaders(req, opts.headers);
+            req.open(opts.method, opts.url, true);
+            setRequestHeaders(req, opts.headers);
 
-    req.timeout = opts.timeout || config.request.defaults.timeout;
-    req.onloadend = req.ontimeout = req.onabort = onReady;
+            req.timeout = opts.timeout || config.request.defaults.timeout;
+            req.onloadend = req.ontimeout = req.onabort = function (e) {
+                abort = null;
+                if (progress) req.upload.onprogress = undefined;
+                _onReady(e.type, req, callback, resolve, reject);
+            };
 
-    var xPromise = _createXPromise(req);
+            if (opts.binary)
+                req.send(fileData);
+            else {
+                var formData = new FormData();
+                formData.append('file', fileData);
+                req.send(formData);
+            }
 
-    if (opts.binary)
-        req.send(fileData);
-    else {
-        var formData = new FormData();
-        formData.append('file', fileData);
-        req.send(formData);
-    }
+            req[config.request.optionsKey] = opts;
 
-    req[config.request.optionsKey] = opts;
+            if (opts.trackCompletion !== false) _pendingRequests.push(req);
 
-    if (opts.trackCompletion !== false) _pendingRequests.push(req);
+            abort = function () {
+                if (abort) {
+                    abort = null;
+                    req.abort();
+                }
+            };
 
-    return xPromise.promise;
-
-    function onReady(e) {
-        if (progress) req.upload.onprogress = undefined;
-        _onReady(req, callback, xPromise, e.type);
-    }
+        }),
+        abort
+    );
 }
 
 


### PR DESCRIPTION
This is a better attempt to avoid using `_createXPromise` to export externally resolve and reject, also exposing the request object around.

The de-contexted `promise.abort` with different internal behaviours gives us the ability to abort not only regular requests, but files and JSONP too in a clean and protected way.