### PR TITLE
Bump all dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "querystringparser": "^0.1.1"
   },
   "devDependencies": {
-    "async": "^2.0.1",
+    "async": "^2.1.2",
     "brfs": "^1.4.3",
-    "browserify": "^13.1.0",
-    "eslintify": "^3.0.0",
+    "browserify": "^13.1.1",
+    "eslintify": "^3.1.0",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-copy": "^1.0.0",
@@ -55,9 +55,9 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.1",
     "karma-firefox-launcher": "^1.0.0",
-    "karma-mocha": "^1.1.1",
+    "karma-mocha": "^1.2.0",
     "karma-spec-reporter": "0.0.26",
     "karma-webdriver-launcher": "^1.0.4",
-    "mocha": "^3.0.2"
+    "mocha": "^3.1.2"
   }
 }


### PR DESCRIPTION
In #67 @WebReflection bumped all dev dependencies creating a merge conflict for #66 and #65, both PRs created by greenkeeper.

As of #67 the suggested updates are satisfied by the version range, but I've made the PR just to make it clear inside package.json. When this is merged we can close #65 and close #66