### PR TITLE
fix: 3rd parts module might need explicit decoration.

### DIFF
--- a/lib/binder.js
+++ b/lib/binder.js
@@ -43,6 +43,7 @@ module.exports = binder;
 function binder(scopeEl, rootScope, bindRootElement, throwOnErrors) {
     return createBinderScope(scopeEl, function(scope, el, attr, throwOnErrors) {
         var info = new ComponentInfo(scope, el, attr, throwOnErrors);
+        attr.decorate();
         return Component.create(info, throwOnErrors);
     }, rootScope, bindRootElement, throwOnErrors);
 }
@@ -131,7 +132,7 @@ function createBinderScope(scopeEl, scopeObjectFactory, rootScope, bindRootEleme
 
 
         // TODO condition after && is a hack, should not be used!
-        if (scopedObject) // && ! scope[attr.compName])
+        if (scopedObject)
             scope[addMethod](scopedObject, attr.compName);
 
         // _.defer(postChildrenBoundMessage, el);


### PR DESCRIPTION
With WP Article Editor we've managed to transform on the fly raw content to milo expected one.

However, some copy and paste operation with components was failing and creating each time a new milo name, which is unknown at runtime.

This fix solves the issue without any visible regression in performances.