### PR TITLE
chore: add boolean `ready` property

### DIFF
--- a/lib/components/c_class.js
+++ b/lib/components/c_class.js
@@ -893,6 +893,9 @@ function Component$insertAtTreePath(treePath, component, nearest) {
 function Component$broadcast(msg, data, callback, synchronously) {
     var postMethod = synchronously ? 'postMessageSync' : 'postMessage';
     this.walkScopeTree(function(component) {
+        if (msg === 'stateready') {
+            component.isReady = true;
+        }
         component[postMethod](msg, data, callback);
     });
 }


### PR DESCRIPTION
There are cases where components events are broadcasted
before `stateready` is ever called.

Since there is apparently no way to actually understand
if a component state is actually ready, this proposal
would like to explicitly add that info.

If you have any better name/idea for the property name,
feel free to shout it out, thank you.