### PR TITLE
fix: Use error message if available in request errors

### DIFF
--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -181,7 +181,7 @@ function _onReady(eventType, req, callback, resolve, reject) {
         postMessage('requestscompleted');
 
     if (error) {
-        var errObj = new Error('Exception: ' + error);
+        var errObj = new Error('Exception: ' + (error.message || error));
         logger.error(error.stack);
         throw errObj;
     }


### PR DESCRIPTION
Request errors seem to expect an error object (https://git.io/vdkrB) with error stack, but attempts to create an error with the entire error object in its constructor.

This changes it so that the error `.message` will be used if it is present, else it will fall back to the original behaviour where the entire error is passed into the constructor.