### PR TITLE
fix: If Drag facet off via config, never set draggable attribute as true

### DIFF
--- a/lib/components/c_facets/Drag.js
+++ b/lib/components/c_facets/Drag.js
@@ -84,8 +84,8 @@ function Drag$start() {
     });
 
     this.owner.onMessages({
-        'getstatestarted': _removeDragAttribute,
-        'getstatecompleted': _addDragAttribute
+        'getstatestarted': _removeDragAttribute.bind(this),
+        'getstatecompleted': _addDragAttribute.bind(this)
     });
 }
 

--- a/lib/components/c_facets/Drag.js
+++ b/lib/components/c_facets/Drag.js
@@ -84,8 +84,8 @@ function Drag$start() {
     });
 
     this.owner.onMessages({
-        'getstatestarted': _removeDragAttribute.bind(this),
-        'getstatecompleted': _addDragAttribute.bind(this)
+        'getstatestarted': { context: this, subscriber: _removeDragAttribute },
+        'getstatecompleted': { context: this, subscriber: _addDragAttribute }
     });
 }
 
@@ -96,12 +96,12 @@ function Drag$start() {
  * @private
  */
 function _addDragAttribute() {
-    if (!this.config.off && this.el) this.el.setAttribute('draggable', true);
+    if (!this.config.off && this.owner.el) this.owner.el.setAttribute('draggable', true);
 }
 
 
 function _removeDragAttribute() {
-    if (this.el) this.el.removeAttribute('draggable');
+    if (this.owner.el) this.owner.el.removeAttribute('draggable');
 }
 
 

--- a/lib/components/c_facets/Drag.js
+++ b/lib/components/c_facets/Drag.js
@@ -96,7 +96,7 @@ function Drag$start() {
  * @private
  */
 function _addDragAttribute() {
-    if (this.el) this.el.setAttribute('draggable', true);
+    if (!this.config.off && this.el) this.el.setAttribute('draggable', true);
 }
 
 
@@ -124,7 +124,7 @@ function onMouseDown(eventType, event) {
 
 
 function onMouseMovement(eventType, event) {
-    var shouldBeDraggable = targetInDragHandle.call(this);
+    var shouldBeDraggable = !this.config.off && targetInDragHandle.call(this);
     this.owner.el.setAttribute('draggable', shouldBeDraggable);
     if (document.body.getAttribute('data-dragEnableEvent') != 'false')
         event.stopPropagation();

--- a/test_browser/components/c_facets/Drag_test.js
+++ b/test_browser/components/c_facets/Drag_test.js
@@ -22,7 +22,7 @@ describe('Drag facet', function() {
     milo.createComponentClass({
         className: 'DragComponent',
         facets: {
-            drag: undefined
+            drag: { off: false }
         }
     });
 

--- a/test_browser/components/c_facets/Drag_test.js
+++ b/test_browser/components/c_facets/Drag_test.js
@@ -22,7 +22,7 @@ describe('Drag facet', function() {
     milo.createComponentClass({
         className: 'DragComponent',
         facets: {
-            drag: { off: false }
+            drag: undefined
         }
     });
 


### PR DESCRIPTION
At the moment you can set `Drag` `off: true` in its config, however the element will still have `draggable="true"` as an attribute. This means that if you turn dragging off for an element, it won't be draggable ever, even if it's parent is. Instead, this PR will change it so that if the `Drag` facet has `off: true` in it's config, it will set the `draggable` attribute as `false` on the element, meaning that the element itself won't be draggable, but that any parent draggable actions won't be blocked.

I believe this is better behaviour, and more expected than the current behaviour.