### PR TITLE
Feat/rename comp opt

### DIFF
--- a/lib/command/index.js
+++ b/lib/command/index.js
@@ -69,7 +69,7 @@ _.extend(Command, {
 function Command$init(func) { // , ... arguments
     check(func, Match.Optional(Function));
     this.func = func || function(){};
-    this.args = _.slice(arguments, 1);    
+    this.args = _.slice(arguments, 1);
 }
 
 

--- a/lib/components/c_class.js
+++ b/lib/components/c_class.js
@@ -846,7 +846,7 @@ function Component$getTopScopeParentWithClass(ComponentClass) {
  *
  * @return {Component}
  */
-function Component$setScopeParentFromDOM() {
+function Component$setScopeParentFromDOM(renameComp=true) {
     var parentEl = this.el.parentNode;
 
     var parent, foundParent;
@@ -858,7 +858,7 @@ function Component$setScopeParentFromDOM() {
 
     this.remove(); // remove component from its current scope (if it is defined)
     if (foundParent) {
-        this.rename(undefined, false);
+        renameComp && this.rename(undefined, false);
         parent.container.scope._add(this);
         return parent;
     }        
@@ -891,9 +891,9 @@ function Component$getComponentAtTreePath(treePath, nearest) {
 }
 
 
-function Component$insertAtTreePath(treePath, component, nearest) {
+function Component$insertAtTreePath(treePath, component, nearest, renameComp=true) {
     var wasInserted = domUtils.insertAtTreePath(this.el, treePath, component.el, nearest);
-    if (wasInserted) component.setScopeParentFromDOM();
+    if (wasInserted) component.setScopeParentFromDOM(renameComp);
     return wasInserted;
 }
 

--- a/lib/components/c_class.js
+++ b/lib/components/c_class.js
@@ -846,7 +846,8 @@ function Component$getTopScopeParentWithClass(ComponentClass) {
  *
  * @return {Component}
  */
-function Component$setScopeParentFromDOM(renameComp=true) {
+function Component$setScopeParentFromDOM(renameComp) {
+    renameComp = renameComp !== false;
     var parentEl = this.el.parentNode;
 
     var parent, foundParent;
@@ -891,7 +892,8 @@ function Component$getComponentAtTreePath(treePath, nearest) {
 }
 
 
-function Component$insertAtTreePath(treePath, component, nearest, renameComp=true) {
+function Component$insertAtTreePath(treePath, component, nearest, renameComp) {
+    renameComp = renameComp !== false;
     var wasInserted = domUtils.insertAtTreePath(this.el, treePath, component.el, nearest);
     if (wasInserted) component.setScopeParentFromDOM(renameComp);
     return wasInserted;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "milojs",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Browser/nodejs reactive programming and data driven DOM manipulation with modular components.",
   "keywords": [
     "framework",


### PR DESCRIPTION
Allow for components to be inserted without changing their component name. Option `renameComp` is added which defaults to true.