### PR TITLE
fix: mol-15780 - Improve drag/drop performance by avoiding needless call

### DIFF
--- a/lib/util/dragdrop.js
+++ b/lib/util/dragdrop.js
@@ -108,7 +108,6 @@ function DragDrop$setComponentState(component, stateStr){
     var dataType = DragDrop.componentDataType();
 
     stateStr && this.dataTransfer.setData(dataType, stateStr);
-    this.dataTransfer.setData('text/html', component.el.outerHTML);
     return stateStr;
 }
 


### PR DESCRIPTION
It doesn't look like anything relies on the `text/html` data type in the drag/drop transfer.  Calculating the `outerHTML` is VERY costly and was causing performance issues as this is called for every drag/move event