### PR TITLE
feat: Requests start in a more deterministic way

### DIFF
--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -26,21 +26,7 @@ var miloCore = require('milo-core')
     , uniqueId = require('./unique_id')
     , config = require('../config')
     , logger = miloCore.util.logger
-    , Messenger = miloCore.Messenger
-    , cancelIdleCallback = window.cancelIdleCallback ||
-        window.clearTimeout
-    , requestIdleCallback = window.requestIdleCallback ||
-        function (cb) {
-            var start = Date.now();
-            return setTimeout(function () {
-                cb({
-                    didTimeout: false,
-                    timeRemaining: function () {
-                        return Math.max(0, 50 - (Date.now() - start));
-                    }
-                });
-            }, 1);
-        };
+    , Messenger = miloCore.Messenger;
 
 module.exports = request;
 
@@ -95,33 +81,27 @@ function request(url, opts, callback) {
              * through its `.then()` callback.
              * In these cases it makes sense to return
              * the Promise first and trigger
-             * the request after, whenever the CPU
-             * is not busy but also never later than
-             * specified request timeout.
+             * the request after
              */
             var data = opts.data;
-            var ric = requestIdleCallback(
-                function (deadline) {
-                    ric = null;
-                    try {
-                        req.send(JSON.stringify(data));
-                    } catch (e) {
-                        console.error('Request Error: ', url, e, opts);
-                    }
-                },
-                { timeout: req.timeout }
-            );
+            var timeoutId = setTimeout(function() {
+                timeoutId = null;
+                try {
+                    req.send(JSON.stringify(data));
+                } catch (e) {
+                    console.error('Request Error: ', url, e, opts);
+                }
+            }, 1);
 
             abort = function () {
-                if (abort && !ric) {
+                if (abort && !timeoutId) {
                     req.abort();
-                } else if (ric) {
-                    cancelIdleCallback(ric);
-                    ric = null;
+                } else if (timeoutId) {
+                    clearTimeout(timeoutId);
+                    timeoutId = null;
                 }
                 abort = null;
             };
-
         }),
         abort
     );


### PR DESCRIPTION
Previous implementation used `requestIdleCallback` to defer requests
being sent to avoid a race condition with cached requests / promise
chaining.  `requestIdleCallback` means that is it possible for a request
to be delayed for multiple seconds before being sent.

It it this none-deterministic behaviour which is making some tests
"flakey".  It doesn't seem like a good idea to keep this... instead the
request execution is delayed via a `setTimeout` call.